### PR TITLE
New Language Support for Rust, Golang, Ruby

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,8 @@ const langs = {
   js: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact'],
   py: ['python'],
   c: ['c', 'cpp'],
-  hash: ['python'],
+  rb: ['ruby'],
+  hash: ['python', 'ruby'],
   slash: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'c', 'c++', 'java']
 };
 
@@ -10,6 +11,10 @@ const patterns = {
   py: {
     print: "^[ \t]*print[ \t]*\(.*\)",
     printComment: "^[ \t]*#[ \t]*print[ \t]*\(.*\)"
+  },
+  rb: {
+    puts: "^[ \t]*puts[ \t]*$",
+    putsComment: "^[ \t]*#[ \t]*puts[ \t]*$"
   },
   js: {
     log: "^[ \t]*console\.log[ \t]*\(.*\)",

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,9 +3,10 @@ const langs = {
   py: ['python'],
   c: ['c', 'cpp'],
   rs: ['rust'],
+  go: ['golang'],
   rb: ['ruby'],
   hash: ['python', 'ruby'],
-  slash: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'c', 'c++', 'java', 'rust']
+  slash: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'c', 'c++', 'java', 'rust', 'golang']
 };
 
 const patterns = {
@@ -20,6 +21,9 @@ const patterns = {
   js: {
     log: "^[ \t]*console\.log[ \t]*\(.*\)",
     logComment: "^[ \t]*\/\/[ \t]*console\.log[ \t]*\(.*\)"
+  },
+  go: {
+    printf: "^[ \t]*fmt.Println[ \t]*\(.*\)[ \t]*$"
   },
   c: {
     printf: "^[ \t]*printf[ \t]*\(.*\)[ \t]*;[ \t]*$",

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,9 +2,10 @@ const langs = {
   js: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact'],
   py: ['python'],
   c: ['c', 'cpp'],
+  rs: ['rust'],
   rb: ['ruby'],
   hash: ['python', 'ruby'],
-  slash: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'c', 'c++', 'java']
+  slash: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'c', 'c++', 'java', 'rust']
 };
 
 const patterns = {
@@ -23,6 +24,9 @@ const patterns = {
   c: {
     printf: "^[ \t]*printf[ \t]*\(.*\)[ \t]*;[ \t]*$",
     cout: "^[ \t]*cout.*<<.*;[ \t]*$"
+  },
+  rs: {
+    println: "^[ \t]*println![ \t]*\(.*\)[ \t]*;[ \t]*$",
   },
   comment: {
     hash: "^[ \t]*#.*",

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,8 +2,7 @@ const langs = {
   js: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact'],
   py: ['python'],
   c: ['c', 'cpp'],
-  rb: ['ruby'],
-  hash: ['python', 'ruby'],
+  hash: ['python'],
   slash: ['javascript', 'javascriptreact', 'typescript', 'typescriptreact', 'c', 'c++', 'java']
 };
 
@@ -11,10 +10,6 @@ const patterns = {
   py: {
     print: "^[ \t]*print[ \t]*\(.*\)",
     printComment: "^[ \t]*#[ \t]*print[ \t]*\(.*\)"
-  },
-  rb: {
-    puts: "^[ \t]*puts[ \t]*$",
-    putsComment: "^[ \t]*#[ \t]*puts[ \t]*$"
   },
   js: {
     log: "^[ \t]*console\.log[ \t]*\(.*\)",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,66 @@ export function activate(context: vscode.ExtensionContext) {
         }
       });
     }
+    else if (langs.rs.includes(langId)) {
+      // Rust Stuff println()
+      textEditor.edit(function (editBuilder) {
+        // Iterate through each line
+        for (var i = 0; i < textEditor.document.lineCount; i++) {
+          let linetext = textEditor.document.lineAt(i).text;
+          var newline = linetext;
+
+          if (linetext.match(patterns.rs.println)) {
+            var j = 0;
+            for (j = 0; j < linetext.length; j++) {
+              if (linetext[j] != ' ' && linetext[j] != '\t') break;
+            }
+            newline = [linetext.slice(0, j), "# ", linetext.slice(j)].join('');
+          }
+          var textRange = new vscode.Range(i, textEditor.document.lineAt(i).range.start.character, i, textEditor.document.lineAt(i).range.end.character);
+          editBuilder.replace(textRange, newline);
+        }
+      });
+    }
+    else if (langs.go.includes(langId)) {
+      // Golang Stuff Println()
+      textEditor.edit(function (editBuilder) {
+        // Iterate through each line
+        for (var i = 0; i < textEditor.document.lineCount; i++) {
+          let linetext = textEditor.document.lineAt(i).text;
+          var newline = linetext;
+
+          if (linetext.match(patterns.go.printf)) {
+            var j = 0;
+            for (j = 0; j < linetext.length; j++) {
+              if (linetext[j] != ' ' && linetext[j] != '\t') break;
+            }
+            newline = [linetext.slice(0, j), "# ", linetext.slice(j)].join('');
+          }
+          var textRange = new vscode.Range(i, textEditor.document.lineAt(i).range.start.character, i, textEditor.document.lineAt(i).range.end.character);
+          editBuilder.replace(textRange, newline);
+        }
+      });
+    }
+    else if (langs.rb.includes(langId)) {
+      // Ruby Stuff puts
+      textEditor.edit(function (editBuilder) {
+        // Iterate through each line
+        for (var i = 0; i < textEditor.document.lineCount; i++) {
+          let linetext = textEditor.document.lineAt(i).text;
+          var newline = linetext;
+
+          if (linetext.match(patterns.rb.puts)) {
+            var j = 0;
+            for (j = 0; j < linetext.length; j++) {
+              if (linetext[j] != ' ' && linetext[j] != '\t') break;
+            }
+            newline = [linetext.slice(0, j), "# ", linetext.slice(j)].join('');
+          }
+          var textRange = new vscode.Range(i, textEditor.document.lineAt(i).range.start.character, i, textEditor.document.lineAt(i).range.end.character);
+          editBuilder.replace(textRange, newline);
+        }
+      });
+    }
     else if (langs.c.includes(langId)) {
       // C,C++ Stuff print()
       textEditor.edit(function (editBuilder) {
@@ -129,6 +189,20 @@ export function activate(context: vscode.ExtensionContext) {
           let linetext = textEditor.document.lineAt(i).text;
 
           if (linetext.match(patterns.py.printComment)) {
+            var textRange = new vscode.Range(i, textEditor.document.lineAt(i).range.start.character, i + 1, textEditor.document.lineAt(i + 1).range.start.character);
+            editBuilder.replace(textRange, "");
+          }
+        }
+      });
+    }
+    else if (langs.rb.includes(langId)) {
+      // Ruby Stuff puts comments
+      textEditor.edit(function (editBuilder) {
+        // Iterate through each line
+        for (var i = 0; i < textEditor.document.lineCount; i++) {
+          let linetext = textEditor.document.lineAt(i).text;
+
+          if (linetext.match(patterns.rb.putsComment)) {
             var textRange = new vscode.Range(i, textEditor.document.lineAt(i).range.start.character, i + 1, textEditor.document.lineAt(i + 1).range.start.character);
             editBuilder.replace(textRange, "");
           }


### PR DESCRIPTION
With reference to #2.

Added code that can remove `print` and `log` statements (or their analogues) from the languages:
- Rust
- Golang
- Ruby
