### PR TITLE
Refactored webpack configuration and removed unnecessary comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,6 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [
-    "onCommand:deprint.comment.print",
-    "onCommand:deprint.delete.comment.print",
-    "onCommand:deprint.delete.comment"
-  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,7 @@
     ],
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true /* enable all strict type-checking options */
-    /* Additional Checks */
-    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "strict": true 
   },
   "exclude": [
     "node_modules",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 //@ts-check
 
 'use strict';
-
+const __dirname = path.resolve();
 const path = require('path');
 
 /**@type {import('webpack').Configuration}*/
@@ -18,7 +18,8 @@ const config = {
   },
   devtool: 'nosources-source-map',
   externals: {
-    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    path: 'commonjs path',
     // modules added here also need to be added in the .vsceignore file
   },
   resolve: {


### PR DESCRIPTION
Considering the extension is targeting VS Code version ^1.75 or later, I remove the "activationEvents" declaration from the package.json file. This will not affect the extension's functionality but reduce unnecessary code in the package.json file.

Deleted extra comments 
Fixed bugs 
( Fixed the error related to _dirname and 
modified the externals property in the configuration object to include the path module)
